### PR TITLE
Corrected docstring for `after?`

### DIFF
--- a/src/java_time/core.clj
+++ b/src/java_time/core.clj
@@ -171,7 +171,7 @@
      false)))
 
 (defn after?
-  "Returns non-nil if time entities are ordered from the earliest to the latest
+  "Returns non-nil if time entities are ordered from the latest to the earliest
   (same semantics as `>`):
 
     (after? (local-date 2011) (local-date 2010) (local-date 2009))


### PR DESCRIPTION
Just a quick fix to a confusing docstring.