### PR TITLE
Example formatter names don't work

### DIFF
--- a/src/java_time/format.clj
+++ b/src/java_time/format.clj
@@ -23,7 +23,7 @@
   "Constructs a DateTimeFormatter out of a
 
   * format string - \"YYYY/mm/DD\", \"YYY HH:MM\", etc.
-  * formatter name - :date, :time-no-millis, etc.
+  * formatter name - :iso-date, :iso-time, etc.
 
   Accepts a map of options as an optional second argument:
 


### PR DESCRIPTION
The example formatter names were not available when I tried them:
```clojure
user=> (keys java-time.format/predefined-formatters)
("iso-offset-time" "iso-local-time" "iso-local-date-time" "iso-offset-date" "iso-time" "iso-week-date" "basic-iso-date" "rfc-1123-date-time" "iso-ordinal-date" "iso-zoned-date-time" "iso-instant" "iso-date-time" "iso-offset-date-time" "iso-date" "iso-local-date")
```
Should they be replaced with ones from this list? Or should I have more predefined formatters available?