### PR TITLE
Add docstring to the available-zone-ids fn

### DIFF
--- a/src/java_time/zone.clj
+++ b/src/java_time/zone.clj
@@ -81,7 +81,9 @@
   :implicit-arities [1 2]
   ([] (jt.clock/make (fn [^Clock c] (.getZone c)))))
 
-(defn available-zone-ids []
+(defn available-zone-ids
+  "Returns a set of string identifiers for all available ZoneIds."
+  []
   (ZoneId/getAvailableZoneIds))
 
 ;; offset date/time


### PR DESCRIPTION
Without the docs, it wasn't clear if it returned a set or a seq, and if the contents were strings or ZoneId objects, making inspection (or usage) of the code required