### PR TITLE
Locales can mess up predefined-formatters

### DIFF
--- a/src/java_time/format.clj
+++ b/src/java_time/format.clj
@@ -4,13 +4,14 @@
             [java-time.core :as jt.c]
             [java-time.util :as jt.u])
   (:import [java.time.temporal TemporalAccessor]
-           [java.time.format DateTimeFormatter DateTimeFormatterBuilder ResolverStyle]))
+           [java.time.format DateTimeFormatter DateTimeFormatterBuilder ResolverStyle]
+           java.util.Locale))
 
 (def predefined-formatters
   (->> (jt.u/get-static-fields-of-type DateTimeFormatter DateTimeFormatter)
        (jt.u/map-kv
-         (fn [^String n fmt]
-           [(string/lower-case (.replace n \_ \-)) fmt]))))
+        (fn [^String n fmt]
+          [(.. (.replace n \_ \-) toString (toLowerCase (Locale/US))) fmt]))))
 
 (defn- get-resolver-style [s]
   (if (instance? ResolverStyle s) s

--- a/test/java_time_test.clj
+++ b/test/java_time_test.clj
@@ -1,7 +1,8 @@
 (ns java-time-test
   (:require [clojure.test :refer :all]
             [java-time.util :as jt.u]
-            [java-time :as j]))
+            [java-time :as j])
+  (:import java.util.Locale))
 
 (def clock (j/fixed-clock "2015-11-26T10:20:30.000000040Z" "UTC"))
 
@@ -846,3 +847,14 @@
       (is (= (j/offset-time joda-clock)
              (j/offset-time (DateTime. 2015 11 26 10 20 30 40 (DateTimeZone/forID "UTC"))))))))
 
+(deftest locale-test
+  (let [current-locale (Locale/getDefault)
+        test-langs ["en" "tr" "cn"]]
+    (testing "locale specific rules for lower-case can cause formatters to not be found"
+      (doseq [lang test-langs]
+       (testing lang
+         (try
+           (Locale/setDefault (Locale/forLanguageTag lang))
+           (is (some? (j/formatter :rfc-1123-date-time)))
+           (finally
+             (Locale/setDefault current-locale))))))))


### PR DESCRIPTION
If your JVM is running in the Turkish language / locale, the keyword
:rfc-1123-date-time ends up in the list of predefined-formatters
improperly - it becomes rfc-1123-date-tıme - the "dotless I". This will
break users trying to use a formatter by the keyword.