### PR TITLE
Canonicalize lib names in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,2 @@
 {:deps
- {clj-tuple {:mvn/version "0.2.2"}}}
+ {clj-tuple/clj-tuple {:mvn/version "0.2.2"}}}


### PR DESCRIPTION
Unqualified lib names are being deprecated and will warn in deps.edn