### PR TITLE
minutes and months formatting might be confusing

### DIFF
--- a/src/java_time/format.clj
+++ b/src/java_time/format.clj
@@ -23,7 +23,7 @@
 (defn ^DateTimeFormatter formatter
   "Constructs a DateTimeFormatter out of a
 
-  * format string - \"YYYY/mm/DD\", \"YYY HH:MM\", etc.
+  * format string - \"YYYY/MM/DD\", \"YYY HH:mm\", etc.
   * formatter name - :iso-date, :iso-time, etc.
 
   Accepts a map of options as an optional second argument:


### PR DESCRIPTION
Copypasted the example in the docs in the REPL, got a weird result. Checked on the [javadocs](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html) - turns out that `MM` are months, `mm` are minutes.

So, yeah - it's a minor thing, but this fixes the example in the docs :) 