### PR TITLE
make format string examples less confusing

### DIFF
--- a/src/java_time/format.clj
+++ b/src/java_time/format.clj
@@ -38,7 +38,7 @@
 (defn ^DateTimeFormatter formatter
   "Constructs a DateTimeFormatter out of a
 
-  * format string - \"YYYY/MM/DD\", \"YYY HH:mm\", etc.
+  * format string - \"yyyy/MM/dd\", \"HH:mm\", etc.
   * formatter name - :iso-date, :iso-time, etc.
 
   Accepts a map of options as an optional second argument:


### PR DESCRIPTION
@vandr0iy recently made a commit that fixes the confusing use of "mm" in the custom format string, but didn't spot that both the DD and YYYY specifiers are confusing as well - DD is day-of-year and YYYY is week-based year. almost certainly you would want to use yyyy/MM/dd.

I've stripped the year part out of the second example completely - I can't see you'd ever be likely to want years/hours/minutes or use 3 'Y's
