### PR TITLE
Fix before/after on Interval

### DIFF
--- a/src/java_time/interval.clj
+++ b/src/java_time/interval.clj
@@ -113,11 +113,11 @@
 
     jt.c/Ordered
     (single-before? [i o] (if (jt.t/instant? o)
-                            (.isBefore (.getEnd i) o)
-                            (.isBefore (.getEnd i) (.getStart ^Interval o))))
+                            (.isBefore i ^Instant o)
+                            (.isBefore i ^Interval o)))
     (single-after? [i o] (if (jt.t/instant? o)
-                           (.isAfter (.getStart i) o)
-                           (.isAfter (.getStart i) (.getEnd ^Interval o))))
+                           (.isAfter i ^Instant o)
+                           (.isAfter i ^Interval o)))
 
     jt.c/As
     (as* [o k]


### PR DESCRIPTION
Close https://github.com/dm3/clojure.java-time/issues/52

Note: Please ignore whitespace changes when reviewing, a deftest was missing for threeten-extra.

The end of an Interval is exclusive.