### PR TITLE
Minimal changes necessary for GraalVM native-image to work

### DIFF
--- a/src/java_time/amount.clj
+++ b/src/java_time/amount.clj
@@ -70,24 +70,38 @@
   [micros]
   (Duration/ofNanos (Math/multiplyExact (long micros) 1000)))
 
-(doseq [[fn-name method-name] [['standard-days 'days]
-                               ['hours 'hours]
-                               ['minutes 'minutes]
-                               ['millis 'millis]
-                               ['seconds 'seconds]
-                               ['nanos 'nanos]]]
-  (let [fn-name (with-meta fn-name {:tag Duration})]
-    (eval
-      `(defn ~fn-name
-         ~(str "Duration of a specified number of " method-name ".")
-         [v#]
-         (. Duration ~(symbol (str 'of (string/capitalize (str method-name)))) (long v#))))))
+(defmacro gen-duration-methods
+  []
+  (conj (map (fn [[fn-name method-name]]
+               (let [fn-name (with-meta fn-name {:tag Duration})]
+                 `(defn ~fn-name
+                    ~(str "Duration of a specified number of " method-name ".")
+                    [v#]
+                    (. Duration ~(symbol (str 'of (string/capitalize (str method-name)))) (long v#)))))
+             [['standard-days 'days]
+              ['hours 'hours]
+              ['minutes 'minutes]
+              ['millis 'millis]
+              ['seconds 'seconds]
+              ['nanos 'nanos]])
+        'do))
 
-(doseq [t ['years 'months 'days 'weeks]]
-  (let [fn-name (with-meta t {:tag Period})]
-    (eval
-      `(defn ~fn-name [v#]
-         (. Period ~(symbol (str 'of (string/capitalize (str t)))) (int v#))))))
+(gen-duration-methods)
+
+(defmacro gen-period-methods
+  []
+  (conj (map (fn [fn-name]
+               (let [fn-name (with-meta fn-name {:tag Period})]
+                 `(defn ~fn-name
+                    [v#]
+                    (. Period ~(symbol (str 'of (string/capitalize (str fn-name)))) (int v#)))))
+             ['years
+              'months
+              'days
+              'weeks])
+        'do))
+
+(gen-period-methods)
 
 (deffactory period
   "Creates a period - a temporal entity consisting of years, months and days.

--- a/src/java_time/core.clj
+++ b/src/java_time/core.clj
@@ -170,7 +170,7 @@
        (before? y (first more)))
      false)))
 
-(def not-after? 
+(def not-after?
   "Similar to [[before?]], but also returns truthy if the inputs are equal."
   (complement after?))
 

--- a/src/java_time/sugar.clj
+++ b/src/java_time/sugar.clj
@@ -2,15 +2,26 @@
   (:require [java-time.core :as jt.c]
             [java-time.util :as jt.u]))
 
-(doseq [[day-name day-number]
-        [['monday 1] ['tuesday 2] ['wednesday 3] ['thursday 4] ['friday 5]
-         ['saturday 6] ['sunday 7]]]
-  (eval `(defn ~(symbol (str day-name '?))
-           ~(str "Returns true if the given time entity with the\n"
-                 "  `day-of-week` property falls on a " day-name ".")
-           [o#] (if-let [p# (jt.c/property o# :day-of-week)]
-                  (= (jt.c/value p#) ~day-number)
-                  (throw (java.time.DateTimeException. (str "Day of week unsupported for: " (type o#))))))))
+(defmacro gen-sugar-fns
+  []
+  (conj (map (fn [[day-name day-number]]
+               `(defn ~(symbol (str day-name '?))
+                 ~(str "Returns true if the given time entity with the\n"
+                       "  `day-of-week` property falls on a " day-name ".")
+                 [o#]
+                 (if-let [p# (jt.c/property o# :day-of-week)]
+                   (= (jt.c/value p#) ~day-number)
+                   (throw (java.time.DateTimeException. (str "Day of week unsupported for: " (type o#)))))))
+             [['monday 1]
+              ['tuesday 2]
+              ['wednesday 3]
+              ['thursday 4]
+              ['friday 5]
+              ['saturday 6]
+              ['sunday 7]])
+        'do))
+
+(gen-sugar-fns)
 
 (defn weekend? [dt]
   (or (saturday? dt) (sunday? dt)))


### PR DESCRIPTION
GraalVM issue: https://github.com/oracle/graal/issues/1613#issuecomment-850807598

Repro: https://github.com/FieryCod/graalvm-1613-repro

Cause of change: eval is called twice. Once during compilation and once
during native-image which seems to trigger incorrect offset error

FYI: Tests are not working since, not all parens are matching.