### PR TITLE
Add missing chrono fields (v0.3.3 has breaking changes)

### DIFF
--- a/src/java_time/fields.clj
+++ b/src/java_time/fields.clj
@@ -8,25 +8,36 @@
    :week-of-year    IsoFields/WEEK_OF_WEEK_BASED_YEAR})
 
 (defonce chrono
-  {:era               ChronoField/ERA
-   :year              ChronoField/YEAR
-   :year-of-era       ChronoField/YEAR_OF_ERA
-   :proleptic-month   ChronoField/PROLEPTIC_MONTH
-   :day-of-year       ChronoField/DAY_OF_YEAR
-   :day-of-month      ChronoField/DAY_OF_MONTH
-   :day-of-week       ChronoField/DAY_OF_WEEK
-   :month-of-year     ChronoField/MONTH_OF_YEAR
-   :hour-of-day       ChronoField/HOUR_OF_DAY
-   :hour-of-ampm      ChronoField/HOUR_OF_AMPM
-   :second-of-day     ChronoField/SECOND_OF_DAY
-   :second-of-minute  ChronoField/SECOND_OF_MINUTE
-   :milli-of-day      ChronoField/MILLI_OF_DAY
-   :milli-of-second   ChronoField/MILLI_OF_SECOND
-   :micro-of-day      ChronoField/MICRO_OF_DAY
-   :micro-of-second   ChronoField/MICRO_OF_SECOND
-   :nano-of-day       ChronoField/NANO_OF_DAY
-   :nano-of-second    ChronoField/NANO_OF_SECOND
-   :offset-seconds    ChronoField/OFFSET_SECONDS})
+  {:era                          ChronoField/ERA
+   :year                         ChronoField/YEAR
+   :year-of-era                  ChronoField/YEAR_OF_ERA
+   :proleptic-month              ChronoField/PROLEPTIC_MONTH
+   :day-of-year                  ChronoField/DAY_OF_YEAR
+   :day-of-month                 ChronoField/DAY_OF_MONTH
+   :day-of-week                  ChronoField/DAY_OF_WEEK
+   :month-of-year                ChronoField/MONTH_OF_YEAR
+   :hour-of-day                  ChronoField/HOUR_OF_DAY
+   :hour-of-ampm                 ChronoField/HOUR_OF_AMPM
+   :second-of-day                ChronoField/SECOND_OF_DAY
+   :second-of-minute             ChronoField/SECOND_OF_MINUTE
+   :milli-of-day                 ChronoField/MILLI_OF_DAY
+   :milli-of-second              ChronoField/MILLI_OF_SECOND
+   :micro-of-day                 ChronoField/MICRO_OF_DAY
+   :micro-of-second              ChronoField/MICRO_OF_SECOND
+   :nano-of-day                  ChronoField/NANO_OF_DAY
+   :nano-of-second               ChronoField/NANO_OF_SECOND
+   :offset-seconds               ChronoField/OFFSET_SECONDS
+   :aligned-day-of-week-in-month ChronoField/ALIGNED_DAY_OF_WEEK_IN_MONTH
+   :aligned-day-of-week-in-year  ChronoField/ALIGNED_DAY_OF_WEEK_IN_YEAR
+   :aligned-week-of-month        ChronoField/ALIGNED_WEEK_OF_MONTH
+   :aligned-week-of-year         ChronoField/ALIGNED_WEEK_OF_YEAR
+   :am-pm-of-day                 ChronoField/AMPM_OF_DAY
+   :clock-hour-of-am-pm          ChronoField/CLOCK_HOUR_OF_AMPM
+   :clock-hour-of-day            ChronoField/CLOCK_HOUR_OF_DAY
+   :epoch-day                    ChronoField/EPOCH_DAY
+   :instant-seconds              ChronoField/INSTANT_SECONDS
+   :minute-of-day                ChronoField/MINUTE_OF_DAY
+   :minute-of-hour               ChronoField/MINUTE_OF_HOUR})
 
 (defonce julian
   {:julian-day          JulianFields/JULIAN_DAY

--- a/test/java_time_test.clj
+++ b/test/java_time_test.clj
@@ -774,7 +774,9 @@
       (let [year-month-under-test (j/year-month 2018 3)]
        (is (= 2018 (j/as year-month-under-test :year)))
        (is (= 3 (j/as year-month-under-test :month-of-year)))
-       (is (thrown? Exception (j/as year-month-under-test :day-of-month)))))
+       (is (thrown? Exception (j/as year-month-under-test :day-of-month))))
+      (let [zoned-date-time-test (j/zoned-date-time 2018 3)]
+       (is (= 1519830000 (j/as zoned-date-time-test :instant-seconds)))))
 
     (testing "multiple"
       (is (= [2015 1 1] (j/as (j/local-date 2015 1 1) :year :month-of-year :day-of-month))))


### PR DESCRIPTION
## Problem

The following code returns expected value with v0.3.2 while v0.3.3 throws Exception.

```clj
(require '[java-time :as j])
(j/as (j/zoned-date-time) :instant-seconds))
```

## Expected

`(j/as (j/zoned-date-time) :instant-seconds))` should return integer.

## Actual

Throws the following exception.
```
java.time.DateTimeException: Property :instant-seconds doesn't exist in [2021-10-27T15:34:44.773+09:00[Asia/Tokyo]]!
```

## How to solve

`java-time.properties/chrono-fields` does'nt have a field for `:instant-seconds`, so I added missing fields.
```clj
(clojure.set/difference 
 (set (keys (->map (vals (jt.u/get-static-fields-of-type ChronoField TemporalField)))))
 (set (keys (->map chrono-fields))))
;; => #{:aligned-week-of-month :epoch-day :aligned-week-of-year :minute-of-day :clock-hour-of-day :instant-seconds :aligned-day-of-week-in-month :am-pm-of-day :aligned-day-of-week-in-year :clock-hour-of-am-pm :minute-of-hour}
```
