### PR TITLE
Remove clj-tuple

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,0 @@
-{:deps
- {clj-tuple/clj-tuple {:mvn/version "0.2.2"}}}

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
             :url "http://opensource.org/licenses/MIT"}
   :scm {:name "git"
         :url "http://github.com/dm3/clojure.java-time"}
-  :dependencies [[org.clojure/clojure "1.10.1" :scope "provided"]
-                 [clj-tuple "0.2.2"]]
+  :dependencies [[org.clojure/clojure "1.10.3" :scope "provided"]]
   :profiles {:dev {:dependencies [[criterium "0.4.4"]
                                   [com.taoensso/timbre "4.1.4"]
                                   [org.clojure/tools.namespace "0.2.11"]

--- a/src/java_time/defconversion.clj
+++ b/src/java_time/defconversion.clj
@@ -1,7 +1,5 @@
 (ns java-time.defconversion
-  (:refer-clojure :exclude (vector))
-  (:require [java-time.graph :as g]
-            [clj-tuple :refer (vector)]))
+  (:require [java-time.graph :as g]))
 
 (def graph (atom (g/conversion-graph)))
 

--- a/src/java_time/graph.clj
+++ b/src/java_time/graph.clj
@@ -1,9 +1,6 @@
 (ns java-time.graph
-  (:refer-clojure :exclude (vector))
   (:require [clojure.set :as sets]
             [clojure.string :as string]
-            ;; ~10-15% faster with clj-tuple
-            [clj-tuple :refer (vector)]
             [java-time.potemkin.util :as u]
             [java-time.util :as jt.u])
   (:import [java.util PriorityQueue Queue]))

--- a/src/java_time/potemkin/util.clj
+++ b/src/java_time/potemkin/util.clj
@@ -15,8 +15,6 @@
 ; Partly Copied from https://github.com/ztellman/potemkin/blob/master/src/potemkin/util.clj
 ; to avoid having a dependency
 (ns java-time.potemkin.util
-  (:refer-clojure :exclude (vector))
-  (:require [clj-tuple :refer (vector)])
   (:import [java.util.concurrent ConcurrentHashMap]))
 
 ;;; fast-memoize


### PR DESCRIPTION
Upstream is unmaintained and performance benefits from clj-tuple
are nowadays questionable so it is removed.

Also update clojure version in project.clj.

This fixes isue #80.