### PR TITLE
update docstring for as

### DIFF
--- a/src/java_time/core.clj
+++ b/src/java_time/core.clj
@@ -141,7 +141,7 @@
   entity `o`, e.g.
 
   ```
-  (as (duration 1 :hour) :minutes)
+  (as (duration 1 :hours) :minutes)
   => 60
 
   (as (local-date 2015 9) :year :month-of-year)


### PR DESCRIPTION
No temporal unit found for :hour!

should be `(as (duration 1 :hours) :minutes)`